### PR TITLE
Fix spamming debug log for PIs w/o bluetooth

### DIFF
--- a/user_program/usb4vc_main.py
+++ b/user_program/usb4vc_main.py
@@ -76,12 +76,13 @@ usb4vc_usb_scan.raw_input_event_parser_thread.start()
 
 while 1:
     time.sleep(2)
-    try:
-        ertm_status = subprocess.getoutput("cat /sys/module/bluetooth/parameters/disable_ertm").replace('\n', '').replace('\r', '').strip()
-        if ertm_status != 'Y':
-            print('ertm_status:', ertm_status)
-            print("Disabling ERTM....")
-            subprocess.call('echo 1 > /sys/module/bluetooth/parameters/disable_ertm')
-            print("DONE")
-    except Exception:
-        continue
+    if os.path.exists("/sys/module/bluetooth/parameters/disable_ertm"):
+        try:
+            ertm_status = subprocess.getoutput("cat /sys/module/bluetooth/parameters/disable_ertm").replace('\n', '').replace('\r', '').strip()
+            if ertm_status != 'Y':
+                print('ertm_status:', ertm_status)
+                print("Disabling ERTM....")
+                subprocess.call('echo 1 > /sys/module/bluetooth/parameters/disable_ertm')
+                print("DONE")
+        except Exception:
+            continue


### PR DESCRIPTION
This fixes an issue where the usb4vc_debug_log.txt will be spammed every 2 seconds on PIs which do not have bluetooth.