### PR TITLE
Add keyboard remapping support

### DIFF
--- a/user_program/usb4vc_shared.py
+++ b/user_program/usb4vc_shared.py
@@ -625,3 +625,17 @@ gamepad_event_code_name_list = [
 	'BTN_TRIGGER_HAPPY38',
 	'BTN_TRIGGER_HAPPY39',
 	'BTN_TRIGGER_HAPPY40',]
+
+# Generate lookup for keyboard key codes (value -> name).
+#
+# This is separate from code_value_to_name_lookup because that map is geared for gamepad remapping.
+# It is missing many keys, but more importantly it contains some idiosyncracies that I don't want
+# to disturb lest it breaks existing gamepad profiles. (It seems to conflate BTN_MODE and
+# KEY_MODE, and I have no desire to try to untangle that).
+kb_code_value_to_name_lookup = {}
+for _name, (_value, _type) in code_name_to_value_lookup.items():
+	if _type == 'kb_key' and isinstance(_value, int):
+		# Use a set because a given key may have multiple names (e.g. KEY_HANGEUL vs KEY_HANGUEL).
+		if _value not in kb_code_value_to_name_lookup:
+			kb_code_value_to_name_lookup[_value] = set()
+		kb_code_value_to_name_lookup[_value].add(_name)

--- a/user_program/usb4vc_ui.py
+++ b/user_program/usb4vc_ui.py
@@ -955,6 +955,9 @@ def ui_worker():
 def get_gamepad_protocol():
     return my_menu.current_gamepad_protocol
 
+def get_keyboard_protocol():
+    return my_menu.current_keyboard_protocol
+
 def get_joystick_curve():
     return joystick_curve_list[my_menu.current_joystick_curve_index]
 

--- a/user_program/usb4vc_usb_scan.py
+++ b/user_program/usb4vc_usb_scan.py
@@ -8,6 +8,7 @@ import threading
 import RPi.GPIO as GPIO
 import usb4vc_ui
 from usb4vc_shared import *
+from usb4vc_shared import kb_code_value_to_name_lookup
 import usb4vc_gamepads
 
 """
@@ -282,6 +283,25 @@ def find_keycode_in_mapping(source_code, mapping_dict, usb_gamepad_type):
         target_info['code_neg'] = code_name_to_value_lookup.get(target_info['code_neg'])[0]
     target_info['type'] = lookup_result[1]
     return source_type, target_info
+
+def remap_keyboard_code(source_code, mapping_dict):
+    if not mapping_dict:
+        return source_code
+    source_names = kb_code_value_to_name_lookup.get(source_code)
+    if source_names is None:
+        return source_code
+    # A key could have multiple names; check for all of them.
+    # If it's mapped under different names, I guess the first one wins.
+    for source_name in source_names:
+        if source_name in mapping_dict:
+            target_info = mapping_dict[source_name]
+            target_name = target_info.get('code')
+            if target_name is None:
+                continue
+            lookup_result = code_name_to_value_lookup.get(target_name)
+            if lookup_result is not None:
+                return lookup_result[0]
+    return source_code
 
 def find_furthest_from_midpoint(this_set):
     curr_best = None
@@ -769,6 +789,12 @@ def raw_input_event_worker():
             this_device = opened_device_dict[key]
             this_id = this_device['id']
             try:
+                # struct input_event {
+                #     struct timeval time; // 8 bytes
+                #     unsigned short type; // 2 bytes
+                #     unsigned short code; // 2 bytes
+                #     unsigned int value;  // 4 bytes
+                # };
                 data = this_device['file'].read(16)
             except OSError:
                 print("Device disappeared:", this_device['name'])
@@ -791,7 +817,13 @@ def raw_input_event_worker():
             if data[0] == EV_KEY:
                 # keyboard keys
                 if 0x1 <= event_code <= 248 and event_code not in gamepad_buttons_as_kb_codes:
-                    xfer_when_not_busy(make_keyboard_spi_packet(data, this_id))
+                    kb_protocol = usb4vc_ui.get_keyboard_protocol()
+                    kb_mapping = kb_protocol.get('mapping') if kb_protocol else None
+                    remapped_code = remap_keyboard_code(event_code, kb_mapping)
+                    kb_data = list(data)
+                    kb_data[2] = remapped_code & 0xff         # (lsb) unsigned short code
+                    kb_data[3] = (remapped_code >> 8) & 0xff  # (msb)
+                    xfer_when_not_busy(make_keyboard_spi_packet(kb_data, this_id))
                 # Mouse buttons
                 elif 0x110 <= event_code <= 0x117:
                     mouse_status_dict[event_code] = data[4]


### PR DESCRIPTION
This adds keyboard remapping support.

The actual reason I am implementing this is because the Apple IIGS uses the "power" key on an ADB keyboard as a "reset" key, and the reset key is extremely important in Apple II land. Actually I would argue that it IS a reset key, not a power key, because the IIGS is the first machine with ADB. In any case, virtually no PC keyboards have a power/reset key, because why would they? There is a key scan code for it, so it seems like a reasonable thing for a user to just remap some other key to be the power key. (Note that currently this doesn't work, because the ADB card firmware handles the power key incorrectly, but we'll get there, baby steps 😉)

 I imagine this could be useful for other things too, like if you want to play an old shooter that uses arrow keys, and you are used to WASD.

The actual remappings are loaded from JSON files with basically the same format as gamepad remappings except that you specify `protocol_list_keyboard` for `device_type` and set `protocol_board` and `protocol_name` accordingly. Here's an example:

```json
{
  "device_type": "protocol_list_keyboard",
  "display_name": "ADB F16->PWR",
  "mapping": {"KEY_F16": {"code": "KEY_POWER"}},
  "protocol_board": "Lisa/Mac/ADB",
  "protocol_name": "ADB_KB"
}
```

There will be a corresponding PR opened for the configurator to allow you to easily generate this JSON files.