### PR TITLE
Various ADB fixes to support the Apple IIGS

### DIFF
--- a/firmware/apple_lisa_mac_adb/Inc/adb.h
+++ b/firmware/apple_lisa_mac_adb/Inc/adb.h
@@ -29,7 +29,14 @@
 #define ADB_CMD_TYPE_LISTEN 2
 #define ADB_CMD_TYPE_TALK 3
 
-#define ADB_CHANGE_ADDR 0xFE
+// Register 3 commands (lower 8 bits)
+#define ADB_LISTEN3_SELF_TEST   0xFF  // Perform self-test
+#define ADB_LISTEN3_CHANGE_ADDR 0xFE  // Change address only
+#define ADB_LISTEN3_ACTIVATOR   0xFD  // Activator relocation
+#define ADB_LISTEN3_SET_FLAGS   0x00  // Update address and flags
+
+// Register 3 flags
+#define ADB_REG3_SRQ_ENABLE 0x2000  // Bit 13: Service Request Enable
 
 // #define DEBUG0_HI() HAL_GPIO_WritePin(DEBUG0_GPIO_Port, DEBUG0_Pin, GPIO_PIN_SET)
 // #define DEBUG0_LOW() HAL_GPIO_WritePin(DEBUG0_GPIO_Port, DEBUG0_Pin, GPIO_PIN_RESET)
@@ -59,18 +66,31 @@
 #define KEY_RIGHTALT 100
 #define KEY_RIGHTMETA 126
 
+#define KEY_POWER 116
+
 #define ADB_CLK_35 34
 #define ADB_CLK_65 64
 #define EV_TO_ADB_LOOKUP_SIZE 186
 #define ADB_DEFAULT_TIMEOUT_US 25000
 #define ADB_KEY_UNKNOWN 255
 #define ADB_KEY_CAPSLOCK 57
+#define ADB_KEY_POWER 127
+
+// Left-side modifier scan codes (standard)
+#define ADB_KEY_LEFT_CONTROL 54
+#define ADB_KEY_LEFT_SHIFT 56
+#define ADB_KEY_LEFT_OPTION 58
+
+// Right-side modifier scan codes (extended, only when handler ID == 0x03)
+#define ADB_KEY_RIGHT_SHIFT 123
+#define ADB_KEY_RIGHT_OPTION 124
+#define ADB_KEY_RIGHT_CONTROL 125
 
 void adb_init(GPIO_TypeDef* data_port, uint16_t data_pin, GPIO_TypeDef* psw_port, uint16_t psw_pin);
 uint8_t adb_recv_cmd(uint8_t* data);
 uint8_t parse_adb_cmd(uint8_t data);
 void adb_reset(void);
-void adb_release_lines(void);
+void adb_release(void);
 uint8_t adb_send_response_16b(uint16_t data);
 void send_srq(void);
 int32_t adb_wait_until_change(int32_t timeout_us);
@@ -79,6 +99,8 @@ extern uint8_t adb_mouse_current_addr, adb_kb_current_addr, adb_rw_in_progress;
 extern const uint8_t linux_ev_to_adb_lookup[EV_TO_ADB_LOOKUP_SIZE];
 extern uint16_t adb_kb_reg2;
 extern uint8_t adb_kb_enabled, adb_mouse_enabled;
+extern uint8_t adb_kb_srq_enabled, adb_mouse_srq_enabled;
+extern uint8_t adb_kb_handler_id;
 extern volatile uint32_t next_busy_off;
 #ifdef __cplusplus
 }

--- a/firmware/apple_lisa_mac_adb/Src/adb.c
+++ b/firmware/apple_lisa_mac_adb/Src/adb.c
@@ -13,6 +13,8 @@ uint16_t adb_data_pin;
 uint16_t adb_kb_reg2 = 0xffff; // all key released, all LED off
 uint8_t adb_mouse_current_addr, adb_kb_current_addr, adb_rw_in_progress;
 uint8_t adb_kb_enabled, adb_mouse_enabled;
+uint8_t adb_kb_srq_enabled = 1, adb_mouse_srq_enabled = 1;
+uint8_t adb_kb_handler_id = 0x05; // AEK/AEKII/AppleDesign ISO
 
 #define ADB_PSW_HI() HAL_GPIO_WritePin(adb_psw_port, adb_psw_pin, GPIO_PIN_SET)
 #define ADB_PSW_LOW() HAL_GPIO_WritePin(adb_psw_port, adb_psw_pin, GPIO_PIN_RESET)
@@ -67,7 +69,7 @@ const uint8_t linux_ev_to_adb_lookup[EV_TO_ADB_LOOKUP_SIZE] =
   39, // EV40 KEY_APOSTROPHE
   50, // EV41 KEY_GRAVE
   56, // EV42 KEY_LEFTSHIFT
-  ADB_KEY_UNKNOWN, // EV43 KEY_BACKSLASH
+  0x2A, // EV43 KEY_BACKSLASH
   6, // EV44 KEY_Z
   7, // EV45 KEY_X
   8, // EV46 KEY_C
@@ -212,19 +214,25 @@ const uint8_t linux_ev_to_adb_lookup[EV_TO_ADB_LOOKUP_SIZE] =
   113, // EV185 KEY_F15
 };
 
-void adb_release_lines(void)
+void adb_release(void)
 {
   ADB_PSW_HI();
   ADB_DATA_HI();
+  next_busy_off = 0;
+  PCARD_BUSY_LOW();
 }
 
 void adb_reset(void)
 {
+  // Host-initiated ADB reset. Return registers to default state.
+  // Some devices are known to maintain the handler ID across a reset,
+  // but I don't think you're supposed to.
   adb_kb_current_addr = ADB_KB_DEFAULT_ADDR;
   adb_mouse_current_addr = ADB_MOUSE_DEFAULT_ADDR;
-  adb_release_lines();
-  next_busy_off = 0;
-  PCARD_BUSY_LOW();
+  adb_kb_srq_enabled = 1;
+  adb_mouse_srq_enabled = 1;
+  adb_kb_handler_id = 0x05;
+  adb_release();
 }
 
 void adb_init(GPIO_TypeDef* data_port, uint16_t data_pin, GPIO_TypeDef* psw_port, uint16_t psw_pin)
@@ -405,7 +413,11 @@ uint8_t parse_adb_cmd(uint8_t data)
 
   if(cmd == ADB_CMD_TYPE_TALK && reg == 3 && addr == adb_mouse_current_addr && adb_mouse_enabled)
   {
-    uint16_t response = 0x6001; // 0110 0000 0000 0001, device handler 0x1, 100dps apple desktop bus mouse
+    // Base: 0100 0000 0000 0001, device handler 0x1, 100dps apple desktop bus mouse
+    // Bit 14 = 1 (no exceptional event), Bit 13 = SRQ enable state
+    uint16_t response = 0x4001;
+    if(adb_mouse_srq_enabled)
+      response |= ADB_REG3_SRQ_ENABLE;
     uint16_t rand_id = (rand() % 0xf) << 8;
     response |= rand_id;
     adb_send_response_16b(response);
@@ -413,7 +425,11 @@ uint8_t parse_adb_cmd(uint8_t data)
 
   if(cmd == ADB_CMD_TYPE_TALK && reg == 3 && addr == adb_kb_current_addr && adb_kb_enabled)
   {
-    uint16_t response = 0x6005; // 0110 0000 0000 0101, device handler 0x5, appledesign keyboard
+    // Bit 14 = 1 (no exceptional event), Bit 13 = SRQ enable state
+    // Bits 0-7 = device handler ID
+    uint16_t response = 0x4000 | adb_kb_handler_id;
+    if(adb_kb_srq_enabled)
+      response |= ADB_REG3_SRQ_ENABLE;
     uint16_t rand_id = (rand() % 0xf) << 8;
     response |= rand_id;
     adb_send_response_16b(response);
@@ -423,16 +439,50 @@ uint8_t parse_adb_cmd(uint8_t data)
   {
     uint16_t host_cmd;
     adb_listen_16b(&host_cmd);
-    if((host_cmd & ADB_CHANGE_ADDR) == ADB_CHANGE_ADDR)
-      adb_mouse_current_addr = (host_cmd & 0xf00) >> 8;
+    uint8_t listen_cmd = host_cmd & 0xff;
+
+    if(listen_cmd == ADB_LISTEN3_SELF_TEST || listen_cmd == ADB_LISTEN3_ACTIVATOR)
+    {
+      // Self test or activator relocation - not implemented
+    }
+    else if(listen_cmd == ADB_LISTEN3_CHANGE_ADDR)
+    {
+      adb_mouse_current_addr = (host_cmd >> 8) & 0xf;
+    }
+    else if(listen_cmd == ADB_LISTEN3_SET_FLAGS)
+    {
+      adb_mouse_current_addr = (host_cmd >> 8) & 0xf;
+      adb_mouse_srq_enabled = (host_cmd & ADB_REG3_SRQ_ENABLE) ? 1 : 0;
+    }
   }
 
   if(cmd == ADB_CMD_TYPE_LISTEN && reg == 3 && addr == adb_kb_current_addr)
   {
     uint16_t host_cmd;
     adb_listen_16b(&host_cmd);
-    if((host_cmd & ADB_CHANGE_ADDR) == ADB_CHANGE_ADDR)
-      adb_kb_current_addr = (host_cmd & 0xf00) >> 8;
+    uint8_t listen_cmd = host_cmd & 0xff;
+
+    if(listen_cmd == ADB_LISTEN3_SELF_TEST || listen_cmd == ADB_LISTEN3_ACTIVATOR)
+    {
+      // Self test or activator relocation - not implemented
+    }
+    else if(listen_cmd == ADB_LISTEN3_CHANGE_ADDR)
+    {
+      adb_kb_current_addr = (host_cmd >> 8) & 0xf;
+    }
+    else if(listen_cmd == ADB_LISTEN3_SET_FLAGS)
+    {
+      adb_kb_current_addr = (host_cmd >> 8) & 0xf;
+      adb_kb_srq_enabled = (host_cmd & ADB_REG3_SRQ_ENABLE) ? 1 : 0;
+    }
+    else
+    {
+      // Apple Extended Keyboard will accept handler ID 2, 3, or 5.
+      // Handler ID 3 enables extended right-side modifier codes.
+      // Handler 2 and 5 are functionally identical afaict.
+      if(listen_cmd == 0x02 || listen_cmd == 0x03 || listen_cmd == 0x05)
+        adb_kb_handler_id = listen_cmd;
+    }
   }
 
   if(cmd == ADB_CMD_TYPE_TALK && reg == 0 && addr == adb_mouse_current_addr)

--- a/firmware/apple_lisa_mac_adb/Src/main.c
+++ b/firmware/apple_lisa_mac_adb/Src/main.c
@@ -99,6 +99,11 @@ mouse_event latest_mouse_event;
 uint8_t spi_error_occured;
 uint8_t protocol_status_lookup[PROTOCOL_LOOKUP_SIZE];
 
+uint8_t capslock_counter;
+
+// Track which keys are currently pressed (for repopulating buffer after ADB reset)
+uint8_t key_state[EV_TO_ADB_LOOKUP_SIZE];
+
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -225,7 +230,11 @@ void parse_spi_buf(uint8_t* spibuf)
   }
   else if(spibuf[SPI_BUF_INDEX_MSG_TYPE] == SPI_MOSI_MSG_TYPE_KEYBOARD_EVENT)
   {
-    kb_buf_add(&my_kb_buf, spibuf[4], spibuf[6]);
+    uint8_t keycode = spibuf[4];
+    uint8_t keyvalue = spibuf[6];
+    kb_buf_add(&my_kb_buf, keycode, keyvalue);
+    if(keycode < EV_TO_ADB_LOOKUP_SIZE)
+      key_state[keycode] = (keyvalue != 0);
   }
   else if(spibuf[SPI_BUF_INDEX_MSG_TYPE] == SPI_MOSI_MSG_TYPE_INFO_REQUEST)
   {
@@ -425,7 +434,22 @@ void adb_mouse_update(void)
   adb_send_response_16b(response);
 }
 
-uint8_t capslock_counter;
+/*
+Repopulate keyboard buffer with currently pressed keys after ADB reset
+This is needed to trigger the "three-finger salute" on the Apple IIGS.
+*/
+void adb_kb_repopulate_from_key_state(void)
+{
+  kb_buf_reset(&my_kb_buf);
+  kb_buf_add(&my_kb_buf, KEY_CAPSLOCK, capslock_counter % 2);
+
+  for(uint8_t keycode = 0; keycode < EV_TO_ADB_LOOKUP_SIZE; keycode++)
+  {
+    if(key_state[keycode] && linux_ev_to_adb_lookup[keycode] != ADB_KEY_UNKNOWN)
+      kb_buf_add(&my_kb_buf, keycode, 1);
+  }
+}
+
 void adb_keyboard_update(void)
 {
   uint8_t buffered_code, buffered_value, adb_code;
@@ -437,6 +461,31 @@ void adb_keyboard_update(void)
     adb_code = linux_ev_to_adb_lookup[buffered_code];
     if(adb_code == ADB_KEY_UNKNOWN)
       goto adb_kb_end;
+    /*
+    Right-side modifier key handling:
+    Handler ID == 0x03: Use extended codes
+    Handler ID != 0x03: Use same codes as left-side keys
+    */
+    if(adb_kb_handler_id != 0x03)
+    {
+      if(adb_code == ADB_KEY_RIGHT_SHIFT)
+        adb_code = ADB_KEY_LEFT_SHIFT;
+      else if(adb_code == ADB_KEY_RIGHT_OPTION)
+        adb_code = ADB_KEY_LEFT_OPTION;
+      else if(adb_code == ADB_KEY_RIGHT_CONTROL)
+        adb_code = ADB_KEY_LEFT_CONTROL;
+    }
+    /*
+    Power/reset key handling:
+    - Send 0x7F7F when pressed (both key slots = 0x7F with key-down bit clear)
+    - Send 0xFFFF when released (both key slots = 0x7F with key-down bit set = 0xFF)
+    */
+    if(adb_code == ADB_KEY_POWER)
+    {
+      response = buffered_value ? 0x7F7F : 0xFFFF;
+      adb_send_response_16b(response);
+      goto adb_kb_end;
+    }
     /*
     adb mac keyboard capslock key seems to behave differently than PC keyboards
     On PC: Capslock down then up = Caps lock on, Capslock down then up again = Caps lock off
@@ -499,6 +548,13 @@ void adb_keyboard_update(void)
       else
         adb_kb_reg2 &= 0xfeff;
     }
+    if(buffered_code == KEY_POWER)
+    {
+      if(buffered_value == 0)
+        adb_kb_reg2 |= 0x1000;
+      else
+        adb_kb_reg2 &= 0xefff;
+    }
     // if(buffered_code == KEY_NUMLOCK)
     // {
     //   if(buffered_value == 0)
@@ -528,7 +584,7 @@ void run_adb(void)
 
   if(adb_kb_enabled == 0 && adb_mouse_enabled == 0)
   {
-    adb_reset();
+    adb_release();
     return;
   }
 
@@ -537,10 +593,11 @@ void run_adb(void)
   if(adb_status == ADB_LINE_STATUS_RESET)
   {
     adb_reset();
+    adb_kb_repopulate_from_key_state();
   }
   else if(adb_status != ADB_OK)
   {
-    adb_reset();
+    adb_release();
     return;
   }
 
@@ -560,7 +617,7 @@ void run_adb(void)
     mouse_srq = 0;
   }
 
-  if((kb_srq && adb_kb_enabled) || (mouse_srq && adb_mouse_enabled))
+  if((kb_srq && adb_kb_enabled && adb_kb_srq_enabled) || (mouse_srq && adb_mouse_enabled && adb_mouse_srq_enabled))
     send_srq();
   else
     adb_wait_until_change(ADB_DEFAULT_TIMEOUT_US);


### PR DESCRIPTION
# Description

Fixing various issues I found while trying to get this to work properly on the Apple IIGS.

1. Track and honor SRQ enable flag in register 3.
   - The Apple IIGS disables mouse SRQs on boot. If we do not honor this, then the host will become overwhelmed with interrupts from the ADB controller.
2. Disentangle the concept of releasing the ADB data lines from the concept of a host-initiated bus reset.
   - A bus reset should reset flags, whereas an error should not, and conflating the two was leading to the SRQ flag getting re-enabled any time there's a transmission glitch (which isn't so rare on an unshielded cable, I could trigger it pretty reliably by wiggling the mouse for a minute or two).
3. Allow keyboard device handler ID to be changed by the host, and only send extended codes if handler ID is $03.
   - The right-hand Control/Option/Shift keys should have the same scan codes as their left-hand variants, UNLESS the handler ID is set to $03.
   - In practice, I can't even find anything that ever sets the handler ID as such, but this is well-understood behavior and I have to imagine that SOMETHING uses such codes - just not by default.
   - If we don't do this, then the IIGS will display gibberish when you press these keys.
4. Correct Power/Reset key code to be double-byte instead of single-byte.
   - The Reset key is expected to send $7f in BOTH bytes of register 0. If we only send it in one byte, then the IIGS does not recognize it.
   - Classic Mac OS also seems to expect the double-byte value, though the key is much less important on Mac than on the IIGS. Mac OS X doesn't appear to care, oddly.
5. Repopulate the keyboard buffer after an ADB bus reset.
   - A bit of a weird one, but needed for the "Control-Command-Reset" reboot sequence to work.
   - The IIGS initiates an ADB bus reset after the Control-Reset chord is broken, but before checking whether or not the Command key is down. At that point, it's already lost its own internal keyboard state, and is apparently relying on the keyboard to re-report the key-down events.
6. Add a definition for the backslash / vertical pipe key ("`\|`"), which I think was missed because this is a different key on an ISO keyboard.
   - This is not actually a IIGS issue, it's just as broken on Mac. I'm just fixing it here because I don't think it warrants a separate PR.

**NOTE:** I think this will conflict against https://github.com/dekuNukem/USB4VC/pull/27, the resolution is to just take both changes (code gets added in the same function).

# Testing

You will need to map some key to be Power/Reset (using the keyboard remapping function) since PC keyboards don't really have a Power key. I used the Pause key but it doesn't really matter.

## Apple IIGS - validate fixes
- [x] [fix 1] ("Check Startup Device!" screen) Moving mouse does not cause slowdown
- [x] [fix 1] (System 6.0.1) Moving mouse does not cause slowdown
- [x] [fix 2] (System 6.0.1) Wiggling the mouse for several minutes does not break anything
- [x] [fix 3] (System 6.0.1) Right-hand modifiers work correctly (do not generate strange characters)
- [x] [fix 3] (BASIC) Right-hand modifiers work correctly (do not generate strange characters)
- [x] [fix 4] (BASIC) Pressing Control-Reset drops back to prompt
- [x] [fix 4+5] (BASIC) Pressing Control-Command-Reset reboots machine
- [x] [fix 4+5] (BASIC) Pressing Control-Option-Reset reboots to 50/60Hz toggle screen
- [x] [fix 4+5] (BASIC) Pressing Control-Command-Option-Reset initiates self-test
- [x] [fix 6] (System 6.0.1) Backslash key works
- [x] [fix 6] (BASIC) Backslash key works

## Macintosh - validate fixes
I'm not going to test these on every machine because the results should not differ.
- [x] [fix 3] (Macintosh G3 Beige, System 9.2.2) In Key Caps app, left and right modifiers appear identical
- [x] [fix 3] (Macintosh G3 Beige, System 9.2.2) After using ADB Prober to change hander to $03, in Key Caps app, right-hand modifiers do not appear (because the app doesn't understand them) but right-Shift DOES change caps state (because the OS _does_ understand it).
- [x] [fix 6] (Macintosh G3 Beige, System 9.2.2) Backslash key works correctly
- [x] [fix 3] (Macintosh G3 Beige, System 10.2.8) In Key Caps app, left and right modifiers appear identical
   - Unable to verify handler $03 in Mac OS X because the system protects the keyboard and mouse from having commands sent to them. I know some versions of the Darwin kernel have [code](https://github.com/apple-oss-distributions/AppleADBKeyboard/blob/8ded65e596fceeb6f84b6a3295f14990a7850992/AppleADBKeyboard.cpp#L470-L480) that should switch to handler $03 on boot, but the code is not present in Jaguar which is the newest OS I can get working on this thing
   - Probably the only Mac you could test that on would be a G4 "Yikes!" since it has a secret ADB port and can run Leopard...
- [x] [fix 6] (Macintosh G3 Beige, System 10.2.8) Backslash key works correctly

## Regression tests
- [x] Macintosh SE (System 6.0.8) - mouse and keyboard behave normally
- [x] Macintosh LC II (System 7.5) - mouse and keyboard behave normally
- [x] Macintosh Performa 578 (System 7.5.3) - mouse and keyboard behave normally
- [x] Power Macintosh 7100/80 (System 8.6) - mouse and keyboard behave normally
- [x] Power Macintosh G3 Beige (System 9.2.2) - mouse and keyboard behave normally
- [x] Power Macintosh G3 Beige (System 10.2.8) - mouse and keyboard behave normally
