### PR TITLE
Add ADB power key pin 2 control for Mac power-on

### DIFF
--- a/firmware/apple_lisa_mac_adb/Inc/adb.h
+++ b/firmware/apple_lisa_mac_adb/Inc/adb.h
@@ -59,6 +59,8 @@
 #define KEY_RIGHTALT 100
 #define KEY_RIGHTMETA 126
 
+#define KEY_POWER 116
+
 #define ADB_CLK_35 34
 #define ADB_CLK_65 64
 #define EV_TO_ADB_LOOKUP_SIZE 186
@@ -74,6 +76,8 @@ void adb_release_lines(void);
 uint8_t adb_send_response_16b(uint16_t data);
 void send_srq(void);
 int32_t adb_wait_until_change(int32_t timeout_us);
+void adb_psw_assert(void);
+void adb_psw_release(void);
 
 extern uint8_t adb_mouse_current_addr, adb_kb_current_addr, adb_rw_in_progress;
 extern const uint8_t linux_ev_to_adb_lookup[EV_TO_ADB_LOOKUP_SIZE];

--- a/firmware/apple_lisa_mac_adb/Src/adb.c
+++ b/firmware/apple_lisa_mac_adb/Src/adb.c
@@ -461,6 +461,12 @@ void send_srq(void)
   ADB_DATA_HI();
 }
 
+void adb_psw_assert(void)
+{
+  ADB_PSW_LOW();
+}
 
-
-
+void adb_psw_release(void)
+{
+  ADB_PSW_HI();
+}

--- a/firmware/apple_lisa_mac_adb/Src/main.c
+++ b/firmware/apple_lisa_mac_adb/Src/main.c
@@ -225,7 +225,18 @@ void parse_spi_buf(uint8_t* spibuf)
   }
   else if(spibuf[SPI_BUF_INDEX_MSG_TYPE] == SPI_MOSI_MSG_TYPE_KEYBOARD_EVENT)
   {
-    kb_buf_add(&my_kb_buf, spibuf[4], spibuf[6]);
+    uint8_t keycode = spibuf[4];
+    uint8_t keyvalue = spibuf[6];
+    kb_buf_add(&my_kb_buf, keycode, keyvalue);
+
+    if(keycode == KEY_POWER && is_protocol_enabled(PROTOCOL_ADB_KB))
+    {
+      // For power-on to work, close JP2 or JP9 and remove R6.
+      if(keyvalue)
+        adb_psw_assert();
+      else
+        adb_psw_release();
+    }
   }
   else if(spibuf[SPI_BUF_INDEX_MSG_TYPE] == SPI_MOSI_MSG_TYPE_INFO_REQUEST)
   {

--- a/getting_started.md
+++ b/getting_started.md
@@ -230,6 +230,18 @@ Want to design a custom case? [Click me](pcb/plates) for dimension drawings.
 
 * Not a high-priority bug, might work on it when I have time.
 
+#### ADB Soft-Power-On doesn't work out-of-box
+
+* To power on a Mac that supports soft-power-on via the keyboard, you will need to modify your Lisa/Mac/ADB protocol card.
+
+* 🚨 **ONLY ATTEMPT THIS IF YOU KNOW WHAT YOU ARE DOING** 🚨 Soldering and desoldering components is a good way to break something.
+
+* You must close either JP2 (pin header between the two ADB ports) or JP9 (solder jumper in same place on back of board) so the signal can reach the ADB port.
+
+* You must also remove R6 which should not be installed. It was removed from the design files but may still exist on shipping boards.
+
+* You must also [map a key](https://github.com/dekuNukem/usb4vc-configurator?tab=readme-ov-file#keyboard-mappings) to act as KEY_POWER, if your USB keyboard does not have a power key (which it probably doesn't).
+
 ## Questions or Comments?
 
 Feel free to ask in official [Discord Chatroom](https://discord.gg/HAuuh3pAmB), raise a [Github issue](https://github.com/dekuNukem/USB4VC/issues), [DM on Twitter](https://twitter.com/dekuNukem_), or email `dekunukem` `gmail.com`!


### PR DESCRIPTION
# Summary

Enable the power key to power on some Macintosh machines by taking pin 2 low when it is pressed.

# Description

Some Macs support powering on via the keyboard, rather than a physical power switch. Many Macs that support this also have a power button, but importantly, *some do not*. For such Macs, the ability to power on via the keyboard is imperative. An example is the Performa 578 - you can't power it on without this fix.

For this to work, you must close JP2 or JP9 on the protocol card, to connect the ADB pin to the microcontroller, and remove R6 as well. The R6 resistor is a mistake in the PCB design that appears to have already been corrected in the design files, but the shipping boards still have it. It seems to be intended to act as a pull-up on the power line, but that would be unnecessary even if it worked. In actual fact, because the +5V line isn't powered when the computer is off, it actually tends to act as a pull-DOWN, resulting in erratic behavior.

**NOTE:** I think this will conflict against https://github.com/dekuNukem/USB4VC/pull/26, the resolution is to just take both changes (code gets added in the same function).

# Testing

- [x] Macintosh IIsi - power key turns on the computer
- [x] Macintosh Performa 578 - power key turns on the computer
- [x] Power Macintosh 7100/80 - power key turns on the computer
- [x] Power Macintosh G3 Beige - power key turns on the computer